### PR TITLE
Add support for ICTC-G-1 controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This automation will bring the following functionalities to IKEA E1743:
 - Manual increase/decrease of brightness
 - Smooth increase/decrease (holding button) of brightness
 
+This automation will bring the following functionalities to IKEA ICTC-G-1:
+
+- Turn off light(s) (quickly rotating left)
+- Turn on light(s) at full brightness (quickly rotating right)
+- Smooth increase/decrease of brightness (rotating right/left)
+
 ## Installation
 
 ### HACS
@@ -44,6 +50,16 @@ For IKEA E1743:
 nameOfYourInstanceApp:
   module: z2m_ikea_controller
   class: E1743Controller
+  sensor: <sensor(s) entity id>
+  light: <light or group entity id>
+```
+
+For IKEA ICTC-G-1:
+
+```yaml
+nameOfYourInstanceApp:
+  module: z2m_ikea_controller
+  class: ICTCG1Controller
   sensor: <sensor(s) entity id>
   light: <light or group entity id>
 ```


### PR DESCRIPTION
The ICTC-G-1 wireless dimmer from IKEA is out of production but it's still being sold around. 
It works differently from the other controllers but I managed to integrate it quite well, although sometimes the dimming function is not totally fluent and could be a little slow. This is probably caused by the large quantity of messages sent by the dimmer itself and the whole zigbee2mqtt/hass/appdaemon software roundtrip.
Succesfully tested with `delay : 150` in the app configuration.