### PR TITLE
Add device-restricted off to min brightness feature

### DIFF
--- a/apps/z2m_ikea_controller/z2m_ikea_controller.py
+++ b/apps/z2m_ikea_controller/z2m_ikea_controller.py
@@ -17,10 +17,10 @@ DEFAULT_DELAY = 350
 
 
 def action(method):
-    def _action_impl(self, *args):
-        continue_call = self.before_action(method.__name__, *args)
+    def _action_impl(self, *args, **kwargs):
+        continue_call = self.before_action(method.__name__, *args, **kwargs)
         if continue_call:
-            method(self, *args)
+            method(self, *args, **kwargs)
 
     return _action_impl
 
@@ -272,9 +272,9 @@ class LightController(ReleaseHoldController):
     def before_action(self, action, *args):
         to_return = True
         if action == "click" or action == "hold":
-            attribute,direction,*_= args
+            attribute, direction, *_ = args
             light_state = self.get_state(self.light["name"])
-            to_return = light_state == "on" or direction == LightController.DIRECTION_UP and attribute== "brightness" and self.from_off_to_min_brightness
+            to_return = light_state == "on" or direction == LightController.DIRECTION_UP and attribute == self.ATTRIBUTE_BRIGHTNESS and self.from_off_to_min_brightness
         return super().before_action(action, *args) and to_return
 
     @action
@@ -322,7 +322,7 @@ class LightController(ReleaseHoldController):
         min_ = self.attribute_minmax[attribute]["min"]
         step = (max_ - min_) // steps
         new_state_attribute = old + sign * step
-        if self.from_off_to_min_brightness and attribute == "brightness" and  self.get_state(self.light["name"])=="off":
+        if self.from_off_to_min_brightness and attribute == self.ATTRIBUTE_BRIGHTNESS and self.get_state(self.light["name"]) == "off":
             new_state_attribute = min_
         attributes = {attribute: new_state_attribute, "transition": self.delay / 1000}
         if min_ <= new_state_attribute <= max_:


### PR DESCRIPTION
In IKEA Zigbee implementation controllers have the ability to turn on the connected bulb (or light group) at minimum brightness if the action to increment brightness occurs (i.e. pressing the dedicated button for a `E1810`, turning the device to the right for a `ICTC-G-1` etc.).

This PR implements the feature, which can be device restricted, since not all controllers which will be integrated in the future could be designed to have this capability.
The `supports_from_off_to_min_brightness()` method, which can be overridden by every controller, defines whether the device supports this feature or not. By default, devices will not implement this feature.

Also, I had to edit `before_action()` signatures, passing action arguments to the methods, something that could come in handy if more complex checks will have to be performed in the future.

I succesfully tested and enabled the feature on `E1810` and `E1743` controllers. I left the `ICTC-G-1` unsupported since the integration is quite unstable and there are still issues with handling duplicate and unwanted messages.
