### PR TITLE
Support for E1810 as media player controller

### DIFF
--- a/apps/z2m_ikea_controller/z2m_ikea_controller.py
+++ b/apps/z2m_ikea_controller/z2m_ikea_controller.py
@@ -443,6 +443,14 @@ class MediaPlayerController(ReleaseHoldController):
         self.call_service("media_player/media_next_track", entity_id=self.media_player)
 
     @action
+    async def volume_up(self):
+        self.call_service("media_player/volume_up", entity_id=self.media_player)
+
+    @action
+    async def volume_down(self):
+        self.call_service("media_player/volume_down", entity_id=self.media_player)
+
+    @action
     async def hold(self, direction):
         # This variable is responsible to count how many times hold_loop has been called
         # so we don't fall in a infinite loop
@@ -577,6 +585,49 @@ class E1810Controller(LightController):
                 LightController.DIRECTION_UP,
             ),
             5003: self.release,
+        }
+
+
+class E1810MediaPlayerController(MediaPlayerController):
+    # Different states reported from the controller:
+    # toggle, brightness_up_click, brightness_down_click
+    # arrow_left_click, arrow_right_click, brightness_up_hold
+    # brightness_up_release, brightness_down_hold, brightness_down_release,
+    # arrow_left_hold, arrow_left_release, arrow_right_hold
+    # arrow_right_release
+
+    def get_state_actions_mapping(self):
+        return {
+            "toggle": self.play_pause,
+            "brightness_up_click": self.volume_up,
+            "brightness_down_click": self.volume_down,
+            "arrow_left_click": self.previous_track,
+            "arrow_right_click": self.next_track,
+            "brightness_up_hold": (self.hold, Controller.DIRECTION_UP),
+            "brightness_up_release": self.release,
+            "brightness_down_hold": (self.hold, Controller.DIRECTION_DOWN),
+            "brightness_down_release": self.release,
+            "arrow_left_hold": (),
+            "arrow_left_release": (),
+            "arrow_right_hold": (),
+            "arrow_right_release": (),
+        }
+
+    def get_event_actions_mapping(self):
+        return {
+            1002: self.play_pause,
+            2002: self.volume_up,
+            3002: self.volume_down,
+            4002: self.previous_track,
+            5002: self.next_track,
+            2001: (self.hold, Controller.DIRECTION_UP),
+            2003: self.release,
+            3001: (self.hold, Controller.DIRECTION_DOWN),
+            3003: self.release,
+            4001: (),
+            4003: (),
+            5001: (),
+            5003: (),
         }
 
 

--- a/apps/z2m_ikea_controller/z2m_ikea_controller.py
+++ b/apps/z2m_ikea_controller/z2m_ikea_controller.py
@@ -607,10 +607,6 @@ class E1810MediaPlayerController(MediaPlayerController):
             "brightness_up_release": self.release,
             "brightness_down_hold": (self.hold, Controller.DIRECTION_DOWN),
             "brightness_down_release": self.release,
-            "arrow_left_hold": (),
-            "arrow_left_release": (),
-            "arrow_right_hold": (),
-            "arrow_right_release": (),
         }
 
     def get_event_actions_mapping(self):
@@ -624,10 +620,6 @@ class E1810MediaPlayerController(MediaPlayerController):
             2003: self.release,
             3001: (self.hold, Controller.DIRECTION_DOWN),
             3003: self.release,
-            4001: (),
-            4003: (),
-            5001: (),
-            5003: (),
         }
 
 


### PR DESCRIPTION
The Ikea `E1810`, with its 5 buttons and all the different events it can fire, is a feature-rich and flexible device. Given its versatility due to its design, it is not only suitable for controlling light brightness and temperature, but works perfectly also as a media player controller.

This PR enables support for the `E1810` as a media player controller (both for `zigbee2mqtt` and `deCONZ`). Actions are mapped as it follows :
* `brightness_up_hold`:  volume up (hold, multiple steps)
* `brightness_up_release`: volume up (release)
* `brightness_up_click`: volume up (single step)
* `brightness_down_hold`: volume down (hold, multiple steps)
* `brightness_down_release`: volume down (release)
* `brightness_down_click`: volume down (single step)
* `toggle`: play/pause
* `arrow_right_click`: next  track
* `arrow_left_click`: previous track

The following actions are not currently being used by this integration:
* `arrow_left_hold`
* `arrow_left_release`
* `arrow_right_hold`
* `arrow_right_release`

@xaviml are there any media player features which you think could be nice to map to those unused actions? 